### PR TITLE
yield complete output instead of partial

### DIFF
--- a/llm/A_I_Inference_Methods/scripts/flask_api.py
+++ b/llm/A_I_Inference_Methods/scripts/flask_api.py
@@ -111,10 +111,8 @@ def generate_stream():
     thread.start()
 
     def f():
-        completion = ""
         for r in streamer:
-            yield r[len(completion) :]
-            completion = r
+            yield r
 
     return Response(stream_with_context(f()), mimetype="text/event-stream")
 


### PR DESCRIPTION
Change the flask API behavior to yield the complete set of tokens every time instead of only the new tokens.